### PR TITLE
Allow Class without namespace (like "::MyClass")

### DIFF
--- a/gasp/__init__.py
+++ b/gasp/__init__.py
@@ -54,6 +54,11 @@ class doxygen(DoxygenNode):
 
     def prepare_node(self,**ctx):
         self.path = self.doxygen.scope_to_path(self.which)
+        
+        #  Allow Class without namespace (like "::MyClass")
+        if self.path[:2] == '//':
+            self.path = self.path[1:]
+        
         nodes = self.doxygen.get(self.path)
         if len(nodes) == 0:
             self.context = {}        


### PR DESCRIPTION
(in PHP context)
I had error when i wanted to document no namespaced class. Like:

```
<?php

class Cat {

```

So, When documenting like this:

```
.. doxygen:: class/members
   ::Cat
   :public:
   :private:
   :all:
```

This MR propose to replace "//Cat" by "/Cat". Working for me.
